### PR TITLE
Deploy to GitHub releases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -76,4 +76,12 @@ script:
  - SRC_TGZ=$(cabal info . | awk '{print $2;exit}').tar.gz &&
    (cd dist && cabal install --force-reinstalls "$SRC_TGZ")
 
+deploy:
+  provider: releases
+  api_key: "$GITHUB_OAUTH_TOKEN"
+  file:
+    - dist/build/dhall-to-json/dhall-to-json
+    - dist/build/dhall-to-yaml/dhall-to-yaml
+  skip_cleanup: true
+
 # EOF

--- a/.travis.yml
+++ b/.travis.yml
@@ -88,6 +88,7 @@ deploy:
   file: "$TRAVIS_OS_NAME.tar.gz"
   on:
     condition: $DEPLOY_GITHUB_RELEASE = true
+    tags: true
   skip_cleanup: true
 
 # EOF

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ matrix:
     - env: CABALVER=1.22 GHCVER=7.10.2
       compiler: ": #GHC 7.10.2"
       addons: {apt: {packages: [cabal-install-1.22,ghc-7.10.2], sources: [hvr-ghc]}}
-    - env: CABALVER=1.24 GHCVER=8.0.1
+    - env: CABALVER=1.24 GHCVER=8.0.1 DEPLOY_GITHUB_RELEASE=true
       compiler: ": #GHC 8.0.1"
       addons: {apt: {packages: [cabal-install-1.24,ghc-8.0.1], sources: [hvr-ghc]}}
 
@@ -82,6 +82,8 @@ deploy:
   file:
     - dist/build/dhall-to-json/dhall-to-json
     - dist/build/dhall-to-yaml/dhall-to-yaml
+  on:
+    condition: $DEPLOY_GITHUB_RELEASE = true
   skip_cleanup: true
 
 # EOF

--- a/.travis.yml
+++ b/.travis.yml
@@ -76,12 +76,16 @@ script:
  - SRC_TGZ=$(cabal info . | awk '{print $2;exit}').tar.gz &&
    (cd dist && cabal install --force-reinstalls "$SRC_TGZ")
 
+before_deploy:
+  - tar --create --file "$TRAVIS_OS_NAME.tar" --files-from /dev/null
+  - tar --append --file "$TRAVIS_OS_NAME.tar" --directory dist/build/dhall-to-json dhall-to-json
+  - tar --append --file "$TRAVIS_OS_NAME.tar" --directory dist/build/dhall-to-yaml dhall-to-yaml
+  - gzip "$TRAVIS_OS_NAME.tar"
+
 deploy:
   provider: releases
   api_key: "$GITHUB_OAUTH_TOKEN"
-  file:
-    - dist/build/dhall-to-json/dhall-to-json
-    - dist/build/dhall-to-yaml/dhall-to-yaml
+  file: "$TRAVIS_OS_NAME.tar.gz"
   on:
     condition: $DEPLOY_GITHUB_RELEASE = true
   skip_cleanup: true


### PR DESCRIPTION
The linux part of #8.

## What this does

When you create a tag, it will run a build on Travis. After a successful build where the environment variable `DEPLOY_GITHUB_RELEASE` is `true`, it will tar up the `dhall-to-json` and `dhall-to-yaml` binaries and upload them to GH under the tag.

See this tag: https://github.com/joneshf/dhall-json/releases/tag/1.0.8-joneshf-testing-2 and the corresponding build: https://travis-ci.org/joneshf/dhall-json/jobs/304052754

## What this doesn't do

This doesn't have OSX wired up to build yet. If it's alright with you, I'd like to tackle that in a separate PR. I don't know how much work it will be to get it building on travis.

## What you need to do to make things work

This uses a personal access token to allow Travis to create Releases and upload artifacts.

You need to:
1. `Generate new token` for Travis to use: https://github.com/settings/tokens.
1. The scope it needs is `repo:public`: https://docs.travis-ci.com/user/deployment/releases/#Authenticating-with-an-OAuth-token.
1. Set that token as the Environment Variable `GITHUB_OAUTH_TOKEN` in the travis settings: https://travis-ci.org/joneshf/dhall-json/settings

After that, any tag you push should create a GitHub Release.