### PR TITLE
Don't use `QuasiQuotes` language extension

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,6 +1,5 @@
 { mkDerivation, aeson, aeson-pretty, base, bytestring, dhall
-, neat-interpolation, optparse-generic, stdenv, text, trifecta
-, vector, yaml
+, optparse-generic, stdenv, text, trifecta, vector, yaml
 }:
 mkDerivation {
   pname = "dhall-json";
@@ -8,9 +7,7 @@ mkDerivation {
   src = ./.;
   isLibrary = true;
   isExecutable = true;
-  libraryHaskellDepends = [
-    aeson base dhall neat-interpolation text vector
-  ];
+  libraryHaskellDepends = [ aeson base dhall text vector ];
   executableHaskellDepends = [
     aeson aeson-pretty base bytestring dhall optparse-generic text
     trifecta yaml

--- a/dhall-json.cabal
+++ b/dhall-json.cabal
@@ -29,11 +29,10 @@ Source-Repository head
 Library
     Hs-Source-Dirs: src
     Build-Depends:
-        base               >= 4.8.0.0  && < 5  ,
-        aeson              >= 1.0.0.0  && < 1.3,
-        dhall              >= 1.0.1    && < 1.9,
-        neat-interpolation                < 0.4,
-        text               >= 0.11.1.0 && < 1.3,
+        base   >= 4.8.0.0  && < 5  ,
+        aeson  >= 1.0.0.0  && < 1.3,
+        dhall  >= 1.0.1    && < 1.9,
+        text   >= 0.11.1.0 && < 1.3,
         vector
     Exposed-Modules: Dhall.JSON
     GHC-Options: -Wall

--- a/src/Dhall/JSON.hs
+++ b/src/Dhall/JSON.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE OverloadedStrings  #-}
-{-# LANGUAGE QuasiQuotes        #-}
 
 {-| This library only exports a single `dhallToJSON` function for translating a
     Dhall syntax tree to a JSON syntax tree (i.e. a `Value`) for the @aeson@
@@ -107,6 +106,7 @@ module Dhall.JSON (
 
 import Control.Exception (Exception)
 import Data.Aeson (Value)
+import Data.Monoid ((<>))
 import Data.Typeable (Typeable)
 import Dhall.Core (Expr)
 import Dhall.TypeCheck (X)
@@ -117,7 +117,6 @@ import qualified Data.Text.Lazy
 import qualified Data.Text.Lazy.Builder
 import qualified Data.Vector
 import qualified Dhall.Core
-import qualified NeatInterpolation
 
 {-| This is the exception type for errors that might arise when translating
     Dhall to JSON
@@ -129,16 +128,15 @@ data CompileError = Unsupported (Expr X X) deriving (Typeable)
 
 instance Show CompileError where
     show (Unsupported e) =
-        Data.Text.unpack [NeatInterpolation.text|
-$_ERROR: Cannot translate to JSON
-
-Explanation: Only primitive values, records, unions, ❰List❱s, and ❰Optional❱
-values can be translated from Dhall to JSON
-
-The following Dhall expression could not be translated to JSON:
-
-↳ $txt
-|]
+        Data.Text.unpack $
+            "" <> _ERROR <> ": Cannot translate to JSON                                     \n\
+            \                                                                               \n\
+            \Explanation: Only primitive values, records, unions, ❰List❱s, and ❰Optional❱   \n\
+            \values can be translated from Dhall to JSON                                    \n\
+            \                                                                               \n\
+            \The following Dhall expression could not be translated to JSON:                \n\
+            \                                                                               \n\
+            \↳ " <> txt <> "                                                                "
       where
         txt = Data.Text.Lazy.toStrict (Dhall.Core.pretty e)
 


### PR DESCRIPTION
Fixes #12

This allows `dhall-json` to be built by GHCJS