### PR TITLE
Build a mostly statically linked executable

### DIFF
--- a/release.nix
+++ b/release.nix
@@ -1,13 +1,3 @@
-# You can build this repository using Nix by running:
-#
-#     $ nix-build -A dhall-json release.nix
-#
-# You can also open up this repository inside of a Nix shell by running:
-#
-#     $ nix-shell -A dhall-json.env release.nix
-#
-# ... and then Nix will supply the correct Haskell development environment for
-# you
 let
   config = {
     packageOverrides = pkgs: {
@@ -15,7 +5,9 @@ let
         overrides = haskellPackagesNew: haskellPackagesOld: {
           dhall = haskellPackagesNew.callPackage ./dhall.nix { };
 
-          dhall-json = haskellPackagesNew.callPackage ./default.nix { };
+          dhall-json =
+            pkgs.haskell.lib.justStaticExecutables
+              (haskellPackagesNew.callPackage ./default.nix { });
         };
       };
     };
@@ -25,5 +17,5 @@ let
     import <nixpkgs> { inherit config; };
 
 in
-  { dhall-json = pkgs.haskellPackages.dhall-json;
+  { inherit (pkgs.haskellPackages) dhall-json;
   }


### PR DESCRIPTION
This takes advantage of `pkgs.haskell.lib.justStaticExecutables` to
build a smaller executable that statically links all Haskell libraries.
This avoids pulling in the very large runtime dependency on GHC