### PR TITLE
Don't print `ExitSuccess` when using `--help`

### DIFF
--- a/dhall-to-json/Main.hs
+++ b/dhall-to-json/Main.hs
@@ -32,25 +32,26 @@ data Options w = Options
 instance ParseRecord (Options Wrapped)
 
 main :: IO ()
-main = handle $ do
+main = do
     GHC.IO.Encoding.setLocaleEncoding GHC.IO.Encoding.utf8
 
     Options {..} <- Options.Generic.unwrapRecord "Compile Dhall to JSON"
 
-    let encode =
-            if pretty
-            then Data.Aeson.Encode.Pretty.encodePretty
-            else Data.Aeson.encode
+    handle $ do
+        let encode =
+                if pretty
+                then Data.Aeson.Encode.Pretty.encodePretty
+                else Data.Aeson.encode
 
-    let explaining = if explain then Dhall.detailed else id
+        let explaining = if explain then Dhall.detailed else id
 
-    let omittingNull = if omitNull then Dhall.JSON.omitNull else id
+        let omittingNull = if omitNull then Dhall.JSON.omitNull else id
 
-    stdin <- Data.Text.IO.getContents
+        stdin <- Data.Text.IO.getContents
 
-    json <- omittingNull <$> explaining (Dhall.JSON.codeToValue "(stdin)" stdin)
+        json <- omittingNull <$> explaining (Dhall.JSON.codeToValue "(stdin)" stdin)
 
-    Data.ByteString.Char8.putStrLn $ Data.ByteString.Lazy.toStrict $ encode json
+        Data.ByteString.Char8.putStrLn $ Data.ByteString.Lazy.toStrict $ encode json
 
 handle :: IO a -> IO a
 handle = Control.Exception.handle handler

--- a/dhall-to-yaml/Main.hs
+++ b/dhall-to-yaml/Main.hs
@@ -29,20 +29,21 @@ data Options w = Options
 instance ParseRecord (Options Wrapped)
 
 main :: IO ()
-main = handle $ do
+main = do
     GHC.IO.Encoding.setLocaleEncoding GHC.IO.Encoding.utf8
 
     Options{..} <- Options.Generic.unwrapRecord "Compile Dhall to JSON"
 
-    let explaining = if explain then Dhall.detailed else id
+    handle $ do
+        let explaining = if explain then Dhall.detailed else id
 
-    let omittingNull = if omitNull then Dhall.JSON.omitNull else id
+        let omittingNull = if omitNull then Dhall.JSON.omitNull else id
 
-    stdin <- Data.Text.IO.getContents
+        stdin <- Data.Text.IO.getContents
 
-    json <- omittingNull <$> explaining (Dhall.JSON.codeToValue "(stdin)" stdin)
+        json <- omittingNull <$> explaining (Dhall.JSON.codeToValue "(stdin)" stdin)
 
-    Data.ByteString.putStr $ Data.Yaml.encode json 
+        Data.ByteString.putStr $ Data.Yaml.encode json 
 
 handle :: IO a -> IO a
 handle = Control.Exception.handle handler


### PR DESCRIPTION
This fixes the command-line programs to not print `ExitSuccess` when provided
with the `--help` flag

The root cause of this message is that `optparse-applicative` throws
`ExitSuccess` in order to short-circuit the program when the user provides the
`--help` flag and the `handle` function prints all exceptions that bubble
through it.  This change relocates the `handle` function to wrap everything
except option parsing.