### PR TITLE
Switch to `optparse-applicative`

### DIFF
--- a/dhall-json.cabal
+++ b/dhall-json.cabal
@@ -41,13 +41,13 @@ Executable dhall-to-json
     Hs-Source-Dirs: dhall-to-json
     Main-Is: Main.hs
     Build-Depends:
-        base                                  ,
-        aeson                                 ,
-        aeson-pretty                    < 0.9 ,
-        bytestring                      < 0.11,
-        dhall                                 ,
-        dhall-json                            ,
-        optparse-generic >= 1.1.1    && < 1.4 ,
+        base                       ,
+        aeson                      ,
+        aeson-pretty         < 0.9 ,
+        bytestring           < 0.11,
+        dhall                      ,
+        dhall-json                 ,
+        optparse-applicative < 0.15,
         text
     GHC-Options: -Wall
 
@@ -59,7 +59,7 @@ Executable dhall-to-yaml
         bytestring                      < 0.11,
         dhall                                 ,
         dhall-json                            ,
-        optparse-generic >= 1.1.1    && < 1.4 ,
+        optparse-applicative            < 0.15,
         yaml             >= 0.5.0    && < 0.9 ,
         text
     GHC-Options: -Wall

--- a/dhall-to-json/Main.hs
+++ b/dhall-to-json/Main.hs
@@ -1,14 +1,12 @@
-{-# LANGUAGE DataKinds         #-}
-{-# LANGUAGE DeriveGeneric     #-}
-{-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ApplicativeDo     #-}
 {-# LANGUAGE RecordWildCards   #-}
-{-# LANGUAGE TypeOperators     #-}
+{-# LANGUAGE OverloadedStrings #-}
 
 module Main where
 
 import Control.Exception (SomeException)
-import Options.Generic (Generic, ParseRecord, Wrapped, type (<?>), type (:::))
+import Data.Monoid ((<>))
+import Options.Applicative (Parser, ParserInfo)
 
 import qualified Control.Exception
 import qualified Data.Aeson
@@ -19,23 +17,54 @@ import qualified Data.Text.IO
 import qualified Dhall
 import qualified Dhall.JSON
 import qualified GHC.IO.Encoding
-import qualified Options.Generic
+import qualified Options.Applicative
 import qualified System.Exit
 import qualified System.IO
 
-data Options w = Options
-    { explain  :: w ::: Bool <?> "Explain error messages in detail"
-    , pretty   :: w ::: Bool <?> "Pretty print generated JSON"
-    , omitNull :: w ::: Bool <?> "Omit record fields that are null"
-    } deriving (Generic)
+data Options = Options
+    { explain  :: Bool
+    , pretty   :: Bool
+    , omitNull :: Bool
+    }
 
-instance ParseRecord (Options Wrapped)
+parseOptions :: Parser Options
+parseOptions = Options.Applicative.helper <*> do
+    explain  <- parseExplain
+    pretty   <- parsePretty
+    omitNull <- parseOmitNull
+    return (Options {..})
+  where
+    parseExplain =
+        Options.Applicative.switch
+            (   Options.Applicative.long "explain"
+            <>  Options.Applicative.help "Explain error messages in detail"
+            )
+
+    parsePretty =
+        Options.Applicative.switch
+            (   Options.Applicative.long "pretty"
+            <>  Options.Applicative.help "Pretty print generated JSON"
+            )
+
+    parseOmitNull =
+        Options.Applicative.switch
+            (   Options.Applicative.long "omitNull"
+            <>  Options.Applicative.help "Omit record fields that are null"
+            )
+
+parserInfo :: ParserInfo Options
+parserInfo =
+    Options.Applicative.info
+        parseOptions
+        (   Options.Applicative.fullDesc
+        <>  Options.Applicative.progDesc "Compile Dhall to JSON"
+        )
 
 main :: IO ()
 main = do
     GHC.IO.Encoding.setLocaleEncoding GHC.IO.Encoding.utf8
 
-    Options {..} <- Options.Generic.unwrapRecord "Compile Dhall to JSON"
+    Options {..} <- Options.Applicative.execParser parserInfo
 
     handle $ do
         let encode =

--- a/dhall-to-yaml/Main.hs
+++ b/dhall-to-yaml/Main.hs
@@ -1,14 +1,11 @@
-{-# LANGUAGE DataKinds         #-}
-{-# LANGUAGE DeriveGeneric     #-}
-{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards   #-}
-{-# LANGUAGE TypeOperators     #-}
 
 module Main where
 
 import Control.Exception (SomeException)
-import Options.Generic (Generic, ParseRecord, Wrapped, type (<?>), type (:::))
+import Data.Monoid ((<>))
+import Options.Applicative (Parser, ParserInfo)
 
 import qualified Control.Exception
 import qualified Data.ByteString
@@ -17,22 +14,46 @@ import qualified Data.Yaml
 import qualified Dhall
 import qualified Dhall.JSON
 import qualified GHC.IO.Encoding
-import qualified Options.Generic
+import qualified Options.Applicative
 import qualified System.Exit
 import qualified System.IO
 
-data Options w = Options
-    { explain  :: w ::: Bool <?> "Explain error messages in detail"
-    , omitNull :: w ::: Bool <?> "Omit record fields that are null"
-    } deriving (Generic)
+data Options = Options
+    { explain  :: Bool
+    , omitNull :: Bool
+    }
 
-instance ParseRecord (Options Wrapped)
+parseOptions :: Parser Options
+parseOptions = Options.Applicative.helper <*> do
+    explain  <- parseExplain
+    omitNull <- parseOmitNull
+    return (Options {..})
+  where
+    parseExplain =
+        Options.Applicative.switch
+            (   Options.Applicative.long "explain"
+            <>  Options.Applicative.help "Explain error messages in detail"
+            )
+
+    parseOmitNull =
+        Options.Applicative.switch
+            (   Options.Applicative.long "omitNull"
+            <>  Options.Applicative.help "Omit record fields that are null"
+            )
+
+parserInfo :: ParserInfo Options
+parserInfo =
+    Options.Applicative.info
+        parseOptions
+        (   Options.Applicative.fullDesc
+        <>  Options.Applicative.progDesc "Compile Dhall to YAML"
+        )
 
 main :: IO ()
 main = do
     GHC.IO.Encoding.setLocaleEncoding GHC.IO.Encoding.utf8
 
-    Options{..} <- Options.Generic.unwrapRecord "Compile Dhall to JSON"
+    Options {..} <- Options.Applicative.execParser parserInfo
 
     handle $ do
         let explaining = if explain then Dhall.detailed else id

--- a/dhall-to-yaml/Main.hs
+++ b/dhall-to-yaml/Main.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE ApplicativeDo     #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards   #-}
 

--- a/nix/dhall-json.nix
+++ b/nix/dhall-json.nix
@@ -1,5 +1,5 @@
 { mkDerivation, aeson, aeson-pretty, base, bytestring, dhall
-, optparse-generic, stdenv, text, unordered-containers, yaml
+, optparse-applicative, stdenv, text, unordered-containers, yaml
 }:
 mkDerivation {
   pname = "dhall-json";
@@ -11,7 +11,8 @@ mkDerivation {
     aeson base dhall text unordered-containers
   ];
   executableHaskellDepends = [
-    aeson aeson-pretty base bytestring dhall optparse-generic text yaml
+    aeson aeson-pretty base bytestring dhall optparse-applicative text
+    yaml
   ];
   description = "Compile Dhall to JSON or YAML";
   license = stdenv.lib.licenses.bsd3;


### PR DESCRIPTION
This switches to using the lower-level `optparse-applicative` for
command-line option parsing.  The main motivation for this is to support
more complex command-line option parsing that may be necessary for
https://github.com/dhall-lang/dhall-json/issues/27