### PR TITLE
Update stack configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+dist
+dist-*
+.stack-work/

--- a/stack-lts-11.yaml
+++ b/stack-lts-11.yaml
@@ -1,0 +1,3 @@
+resolver: lts-11.17
+extra-deps:
+  - dhall-1.15.1

--- a/stack-lts-11.yaml
+++ b/stack-lts-11.yaml
@@ -1,3 +1,0 @@
-resolver: lts-11.17
-extra-deps:
-  - dhall-1.15.1

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,2 +1,1 @@
-resolver: lts-10.6
-allow-newer: true
+resolver: lts-12.0


### PR DESCRIPTION
The previous config fails for me (with stack-1.7.1) cause it picked up the lts fixed version of dhall  (dhall-1.11.1 for lts-11.10 and dhall-1.8.2 for the original lts-10.6)
I've set the last lts-12.0 for default and keep the last lts-11 for builds requiring the original ghc-8.2.2. Not sure if the last one is needed or desirable, let me know your thoughts about.