### PR TITLE
Add command line option to render many documents

### DIFF
--- a/dhall-json.cabal
+++ b/dhall-json.cabal
@@ -67,6 +67,7 @@ Executable dhall-to-yaml
         dhall-json                             ,
         optparse-applicative                   ,
         yaml                 >= 0.5.0 && < 0.11,
+        vector                                 ,
         text
     GHC-Options: -Wall
 

--- a/dhall-to-yaml/Main.hs
+++ b/dhall-to-yaml/Main.hs
@@ -24,7 +24,7 @@ import qualified System.IO
 data Options = Options
     { explain    :: Bool
     , omitNull   :: Bool
-    , manyDocs   :: Bool
+    , documents  :: Bool
     , conversion :: Conversion
     }
 
@@ -32,7 +32,7 @@ parseOptions :: Parser Options
 parseOptions = Options.Applicative.helper <*> do
     explain    <- parseExplain
     omitNull   <- parseOmitNull
-    manyDocs   <- parseManyDocs
+    documents  <- parseDocuments
     conversion <- Dhall.JSON.parseConversion
     return (Options {..})
   where
@@ -48,9 +48,9 @@ parseOptions = Options.Applicative.helper <*> do
             <>  Options.Applicative.help "Omit record fields that are null"
             )
 
-    parseManyDocs =
+    parseDocuments =
         Options.Applicative.switch
-            (   Options.Applicative.long "manyDocs"
+            (   Options.Applicative.long "documents"
             <>  Options.Applicative.help "If given a Dhall list, output a document for every element"
             )
 
@@ -77,7 +77,7 @@ main = do
 
         json <- omittingNull <$> explaining (Dhall.JSON.codeToValue conversion "(stdin)" stdin)
 
-        let yaml = case (manyDocs, json) of
+        let yaml = case (documents, json) of
               (True, Data.Yaml.Array elems)
                 -> Data.ByteString.intercalate "\n---\n"
                    $ fmap Data.Yaml.encode

--- a/dhall-to-yaml/Main.hs
+++ b/dhall-to-yaml/Main.hs
@@ -12,6 +12,7 @@ import Options.Applicative (Parser, ParserInfo)
 import qualified Control.Exception
 import qualified Data.ByteString
 import qualified Data.Text.IO
+import qualified Data.Vector
 import qualified Data.Yaml
 import qualified Dhall
 import qualified Dhall.JSON
@@ -23,6 +24,7 @@ import qualified System.IO
 data Options = Options
     { explain    :: Bool
     , omitNull   :: Bool
+    , manyDocs   :: Bool
     , conversion :: Conversion
     }
 
@@ -30,6 +32,7 @@ parseOptions :: Parser Options
 parseOptions = Options.Applicative.helper <*> do
     explain    <- parseExplain
     omitNull   <- parseOmitNull
+    manyDocs   <- parseManyDocs
     conversion <- Dhall.JSON.parseConversion
     return (Options {..})
   where
@@ -43,6 +46,12 @@ parseOptions = Options.Applicative.helper <*> do
         Options.Applicative.switch
             (   Options.Applicative.long "omitNull"
             <>  Options.Applicative.help "Omit record fields that are null"
+            )
+
+    parseManyDocs =
+        Options.Applicative.switch
+            (   Options.Applicative.long "manyDocs"
+            <>  Options.Applicative.help "If given a Dhall list, output a document for every element"
             )
 
 parserInfo :: ParserInfo Options
@@ -68,7 +77,14 @@ main = do
 
         json <- omittingNull <$> explaining (Dhall.JSON.codeToValue conversion "(stdin)" stdin)
 
-        Data.ByteString.putStr $ Data.Yaml.encode json 
+        let yaml = case (manyDocs, json) of
+              (True, Data.Yaml.Array elems)
+                -> Data.ByteString.intercalate "\n---\n"
+                   $ fmap Data.Yaml.encode
+                   $ Data.Vector.toList elems
+              _ -> Data.Yaml.encode json
+
+        Data.ByteString.putStr yaml
 
 handle :: IO a -> IO a
 handle = Control.Exception.handle handler


### PR DESCRIPTION
Fix #58

Adds a `--manyDocs` command line option to render a Dhall list as a list of YAML documents in the same stream. (suggestions welcome on a better name for the option)

I opened a patch to upstream (`yaml`) to have access to the YAML stream events (to add `DocumentStart` and `DocumentEnd` where needed), but just concatenating strings in this way is 10x less code and it's much easier to understand/maintain (IMO)