### PR TITLE
Adapt to new Dhall.Map

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -1,0 +1,6 @@
+packages: .
+
+source-repository-package
+    type: git
+    location: https://github.com/dhall-lang/dhall-haskell
+    tag: 70425bd4fce49e7fc57ed94a622e1f72afd24663

--- a/dhall-json.cabal
+++ b/dhall-json.cabal
@@ -36,7 +36,6 @@ Library
         base                      >= 4.8.0.0  && < 5   ,
         aeson                     >= 1.0.0.0  && < 1.5 ,
         dhall                     >= 1.15.0   && < 1.18,
-        insert-ordered-containers                < 1.14,
         optparse-applicative      >= 0.14.0.0 && < 0.15,
         text                      >= 0.11.1.0 && < 1.3 ,
         unordered-containers                     < 0.3

--- a/nix/dhall.nix
+++ b/nix/dhall.nix
@@ -1,39 +1,36 @@
 { mkDerivation, ansi-terminal, base, bytestring, case-insensitive
 , cborg, containers, contravariant, criterion, cryptonite, deepseq
 , Diff, directory, doctest, exceptions, fetchgit, filepath
-, hashable, haskeline, http-client, http-client-tls
-, insert-ordered-containers, lens-family-core, megaparsec, memory
-, mockery, mtl, optparse-applicative, parsers, prettyprinter
-, prettyprinter-ansi-terminal, QuickCheck, quickcheck-instances
-, repline, scientific, serialise, stdenv, tasty, tasty-hunit
-, tasty-quickcheck, template-haskell, text, transformers
-, unordered-containers, vector
+, haskeline, http-client, http-client-tls, lens-family-core
+, megaparsec, memory, mockery, mtl, optparse-applicative, parsers
+, prettyprinter, prettyprinter-ansi-terminal, QuickCheck
+, quickcheck-instances, repline, scientific, serialise, stdenv
+, tasty, tasty-hunit, tasty-quickcheck, template-haskell, text
+, transformers, unordered-containers, vector
 }:
 mkDerivation {
   pname = "dhall";
   version = "1.17.0";
   src = fetchgit {
     url = "https://github.com/dhall-lang/dhall-haskell.git";
-    sha256 = "0fj61llfr2sz8lh2xpryzp7q0ahgqbzgf72ppw34w5ibq5a6gd9l";
-    rev = "fedfa8e41ea8da32c2ee779ce65982544ed4800f";
+    sha256 = "0pivzmmx7qlkqkan0xzjm0il114lxhvpwwlvnc6fdfjaawvgb5bg";
+    rev = "afffa17be44047169cfb335a65ebb63d9d7a7868";
   };
   isLibrary = true;
   isExecutable = true;
   libraryHaskellDepends = [
     ansi-terminal base bytestring case-insensitive cborg containers
     contravariant cryptonite Diff directory exceptions filepath
-    hashable haskeline http-client http-client-tls
-    insert-ordered-containers lens-family-core megaparsec memory mtl
-    optparse-applicative parsers prettyprinter
+    haskeline http-client http-client-tls lens-family-core megaparsec
+    memory mtl optparse-applicative parsers prettyprinter
     prettyprinter-ansi-terminal repline scientific serialise
     template-haskell text transformers unordered-containers vector
   ];
   executableHaskellDepends = [ base ];
   testHaskellDepends = [
-    base containers deepseq directory doctest filepath hashable
-    insert-ordered-containers mockery prettyprinter QuickCheck
-    quickcheck-instances serialise tasty tasty-hunit tasty-quickcheck
-    text transformers vector
+    base containers deepseq directory doctest filepath mockery
+    prettyprinter QuickCheck quickcheck-instances serialise tasty
+    tasty-hunit tasty-quickcheck text transformers vector
   ];
   benchmarkHaskellDepends = [
     base bytestring containers criterion directory serialise text

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,1 +1,7 @@
-resolver: lts-12.0
+resolver: lts-12.12
+extra-deps:
+  - github: dhall-lang/dhall-haskell
+    commit: 70425bd4fce49e7fc57ed94a622e1f72afd24663
+  - megaparsec-7.0.1
+  - repline-0.2.0.0
+  - serialise-0.2.0.0


### PR DESCRIPTION
* Changes to adapt `dhall-json` to the new incoming `dhall-haskell` version
* As `dhall-json` needs the changes of https://github.com/dhall-lang/dhall-haskell/pull/624, i've pinned its version in the `stack.yaml`. Only it will have to change with the new release.